### PR TITLE
Lowercase history table_name before checking if it exists:

### DIFF
--- a/history/management/commands/triggers.py
+++ b/history/management/commands/triggers.py
@@ -182,7 +182,7 @@ def create_history_table(cursor, base_table, pk_name, pk_type):
     """
     Builds the history table (if it doesn't already exist) given the base table name.
     """
-    history_table = truncate_long_name(base_table + '_history')
+    history_table = truncate_long_name(base_table + '_history').lower()
     if not table_exists(cursor, history_table, conf.SCHEMA_NAME):
         params = {
             'schema': conf.SCHEMA_NAME,


### PR DESCRIPTION
We do this because the CREATE TABLE sql command is automatically lower
casing table_name since it is not wrapped in double quotes.  This is an
issue for app labels that have upper case letters.  The table_exists
function is always returning false if the app has upper case letters.
Then, an exception is raised when attempting to create a table with the
same name.